### PR TITLE
Allow prop on new Slack version

### DIFF
--- a/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
+++ b/packages/nodes-base/nodes/Slack/V2/FileDescription.ts
@@ -94,7 +94,7 @@ export const fileFields: INodeProperties[] = [
 			show: {
 				operation: ['upload'],
 				resource: ['file'],
-				'@version': [2.2],
+				'@version': [2.2, 2.3],
 			},
 		},
 		placeholder: '',


### PR DESCRIPTION
Slack node version was bumped to 2.3 but this one keeps the prop field hidden in the UI

## Summary

Can't pick file prop in the UI, so I'm adding the new version on prop show condition.

<img width="444" alt="image" src="https://github.com/user-attachments/assets/66cfed7c-825c-493f-9d4c-8f6e24e503e5">

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)
